### PR TITLE
No newlines between uses

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -70,7 +70,7 @@
 		<properties>
 			<property name="linesCountBeforeFirstUse" value="1"/>
 			<property name="linesCountBeforeFirstUseWhenFirstInClass" value="1"/>
-			<property name="linesCountBetweenUses" value="1"/>
+			<property name="linesCountBetweenUses" value="0"/>
 			<property name="linesCountAfterLastUse" value="2"/>
 			<property name="linesCountAfterLastUseWhenLastInClass" value="1"/>
 		</properties>


### PR DESCRIPTION
Because types are not specified in docblocks but directly in code, which is even more true with PHP 8 and union types.

Because

```php
use Something;

use SomethingElse;

private Foo $foo;
private Bar $bar;
```
looks better when written like
```php
use Something;
use SomethingElse;

private Foo $foo;
private Bar $bar;
```