### PR TITLE
Add trailing comma rules

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -22,6 +22,7 @@
 			<property name="tabIndent" value="true"/>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition">
@@ -75,6 +76,8 @@
 			<property name="linesCountAfterLastUseWhenLastInClass" value="1"/>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInCall"/>
+	<rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
 	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing">


### PR DESCRIPTION
Trailing comma required in these situations:

- `SlevomatCodingStandard.Arrays.TrailingArrayComma`
This sniff enforces trailing commas in multi-line arrays and requires short array syntax `[]`.

- `SlevomatCodingStandard.Functions.RequireTrailingCommaInCall`
This sniff enforces trailing commas in multi-line calls.

- `SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration`
This sniff enforces trailing commas in multi-line declarations.