### PR TITLE
Require slevomat/coding-standard 8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		}
 	],
 	"require": {
-		"php": "^7.1 || ^8.0",
+		"php": "^7.2 || ^8.0",
 		"squizlabs/php_codesniffer": "^3.7.0",
 		"slevomat/coding-standard": "^8.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
 	],
 	"require": {
 		"php": "^7.2 || ^8.0",
-		"squizlabs/php_codesniffer": "^3.7.0",
 		"slevomat/coding-standard": "^8.0"
 	},
 	"autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	"require": {
 		"php": "^7.1 || ^8.0",
 		"squizlabs/php_codesniffer": "^3.7.0",
-		"slevomat/coding-standard": "^7.2.1"
+		"slevomat/coding-standard": "^8.0"
 	},
 	"autoload": {
 		"psr-4": {"Spaze\\CodingStandard\\": "src"}

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -111,7 +111,7 @@
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
-	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
+	<rule ref="SlevomatCodingStandard.Classes.PropertyDeclaration"/>
 	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">
 		<properties>
 			<property name="spacesCountBeforeColon" value="0"/>


### PR DESCRIPTION
Require [slevomat/coding-standard 8.0](https://github.com/slevomat/coding-standard/releases/tag/8.0.0) because it supports my fav PHP 8.1 features, like the new rule `SlevomatCodingStandard.Classes.PropertyDeclaration` which also checks order of all the things (`private readonly int $foo` is ok, `readonly private int $foo` is not even though it can be written like this).