### PR TITLE
Require constructor property promotion

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -67,6 +67,7 @@
 			<property name="maxLinesCountBeforeWithoutComment" value="1"/>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>
 	<rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
 	<rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing">
 		<properties>


### PR DESCRIPTION
PHP 8.0+ feature so code targeting older PHPs would need to exclude it, just like trailing commas in calls for example.

This is how you'd exclude it, dear future me:

```xml
<rule ref="vendor/spaze/coding-standard/src/ruleset.xml">
	<exclude name="SlevomatCodingStandard.Classes.RequireConstructorPropertyPromotion"/>  <!-- 👈 this line -->
</rule>
```