### PR TITLE
Specify where enum cases should be specified in a class

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -44,6 +44,7 @@
 		<properties>
 			<property name="groups" type="array">
 				<element value="uses"/>
+				<element value="enum cases"/>
 				<element value="constants"/>
 				<element value="properties"/>
 				<element value="abstract methods"/>


### PR DESCRIPTION
Below `use`, above constants feels like a good place.