### PR TITLE
Disallow trailing multiline ternary operator

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -86,6 +86,7 @@
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineCondition">
 		<properties>


### PR DESCRIPTION
```php
# wrong
$t = $someCondition ?
	$thenThis :
	$otherwiseThis;

# correct
$t = $someCondition
	? $thenThis
	: $otherwiseThis;
```

[See docs](https://github.com/slevomat/coding-standard/blob/8.9.0/doc/control-structures.md#slevomatcodingstandardcontrolstructuresdisallowtrailingmultilineternaryoperator-)