### PR TITLE
Disallow duplicate whitespaces

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -134,6 +134,7 @@
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Variables.DisallowVariableVariable"/>
+	<rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
 	<rule ref="Squiz.Strings.ConcatenationSpacing">
 		<properties>
 			<property name="spacing" value="1"/>


### PR DESCRIPTION
I've realized I had some of them somewhere. I also use them before comments like `code;  // comment` but also not everywhere so I can let them go, easily.