### PR TITLE
Commenting sniffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	],
 	"require": {
 		"php": "^7.2 || ^8.0",
-		"slevomat/coding-standard": "^8.9"
+		"slevomat/coding-standard": "^8.11"
 	},
 	"require-dev": {
 		"ext-simplexml": "*"

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -77,6 +77,7 @@
 			<property name="linesCountAfterLastUseWhenLastInClass" value="1"/>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Commenting.AnnotationName"/>
 	<rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
 		<properties>
 			<property name="linesCountBeforeFirstContent" value="0"/>

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -87,6 +87,7 @@
 			<property name="linesCountAfterLastContent" value="0"/>
 		</properties>
 	</rule>
+	<rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -78,6 +78,7 @@
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Commenting.AnnotationName"/>
+	<rule ref="SlevomatCodingStandard.Commenting.DeprecatedAnnotationDeclaration"/>
 	<rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing">
 		<properties>
 			<property name="linesCountBeforeFirstContent" value="0"/>

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -88,6 +88,7 @@
 		</properties>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>
+	<rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowTrailingMultiLineTernaryOperator"/>
 	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>


### PR DESCRIPTION
- [Checks incorrect annotation names](https://github.com/slevomat/coding-standard/blob/14169a46713f58cba7bf3fbe959a33cbc3f0d9ff/doc/commenting.md#slevomatcodingstandardcommentingannotationname-)
- [Report `@deprecated` annotations without description](https://github.com/slevomat/coding-standard/blob/14169a46713f58cba7bf3fbe959a33cbc3f0d9ff/doc/commenting.md#slevomatcodingstandardcommentingdeprecatedannotationdeclaration)
- [Reports empty comments](https://github.com/slevomat/coding-standard/blob/14169a46713f58cba7bf3fbe959a33cbc3f0d9ff/doc/commenting.md#slevomatcodingstandardcommentingemptycomment-)
- [Reports documentation comments containing only `@inheritDoc` annotation](https://github.com/slevomat/coding-standard/blob/14169a46713f58cba7bf3fbe959a33cbc3f0d9ff/doc/commenting.md#slevomatcodingstandardcommentinguselessinheritdoccomment-)