### PR TITLE
Don't set `installed_paths` config in ruleset file

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="SpazeCodingStandard">
 	<arg name="tab-width" value="4"/>
-	<config name="installed_paths" value="../../slevomat/coding-standard"/>
 	<rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
 	<rule ref="Generic.WhiteSpace.DisallowSpaceIndent"/>
 	<rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>


### PR DESCRIPTION
The "parent" rules may not be installed in that location, and it prevents using phpcs from a phar file because it is a relative path.

https://www.php.net/phar.interceptfilefuncs:
> instructs phar to intercept fopen(), readfile(), file_get_contents(), opendir(), and all of the stat-related functions. If any of these functions is called from within a phar archive with a relative path, the call is modified to access a file within the phar archive. Absolute paths are assumed to be attempts to load external files from the filesystem.