### PR TITLE
PHP_CodeSniffer 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	],
 	"require": {
 		"php": "^7.2 || ^8.0",
-		"slevomat/coding-standard": "^8.18.1"
+		"slevomat/coding-standard": "^8.23.0"
 	},
 	"require-dev": {
 		"ext-simplexml": "*"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"dev"
 	],
 	"require": {
-		"php": "^7.2 || ^8.0",
+		"php": "^7.4 || ^8.0",
 		"slevomat/coding-standard": "^8.23.0"
 	},
 	"require-dev": {

--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -20,9 +20,11 @@
 		<exclude name="PSR12.Classes.AnonClassDeclaration.CloseBraceAfterBody"/> <!-- 1 blank line checked by Squiz.WhiteSpace.FunctionSpacing.AfterLast -->
 		<exclude name="PSR12.Classes.OpeningBraceSpace.Found"/> <!-- 1 blank like required by Squiz.WhiteSpace.FunctionSpacing.BeforeFirst -->
 		<exclude name="PSR12.Files.DeclareStatement"/>
-		<exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
 		<exclude name="PSR12.Traits.UseDeclaration.BlankLineAfterLastUse"/> <!-- Checked by SlevomatCodingStandard.Classes.TraitUseSpacing -->
 		<exclude name="PSR12.Traits.UseDeclaration.UseAfterBrace"/>
+	</rule>
+	<rule ref="PSR12.Files.FileHeader">
+		<exclude name="PSR12.Files.FileHeader.SpacingAfterTagBlock"/>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
 	<rule ref="SlevomatCodingStandard.Classes.BackedEnumTypeSpacing">


### PR DESCRIPTION
- Require slevomat/coding-standard that uses PHPCS 4.0
- Replace `PSR12.Files.FileHeader.SpacingAfterBlock` with the new modular rules
  - See https://github.com/PHPCSStandards/PHP_CodeSniffer/commit/c9c4d0587fbfbd1c96d9847290025a0e96c966b9 and the [upgrade guide](https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki/Version-4.0-User-Upgrade-Guide#changed-error-codes).
- Require PHP 7.4, the same as PHPCS now requires