### PR TITLE
Don't require spacing after a docblock in a file header

### DIFF
--- a/src/ruleset.xml
+++ b/src/ruleset.xml
@@ -24,6 +24,7 @@
 		<exclude name="PSR12.Traits.UseDeclaration.UseAfterBrace"/>
 	</rule>
 	<rule ref="PSR12.Files.FileHeader">
+		<exclude name="PSR12.Files.FileHeader.SpacingAfterDocblockBlock"/>
 		<exclude name="PSR12.Files.FileHeader.SpacingAfterTagBlock"/>
 	</rule>
 	<rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>


### PR DESCRIPTION
Sometimes, there are some file-level docblocks and they don't need to be separated with an empty line.

Follow-up to #29